### PR TITLE
feat(app): dual-channel QR codes

### DIFF
--- a/app/components/Generate.vue
+++ b/app/components/Generate.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
 import { fromUint8Array } from 'js-base64'
 import { blockToBinary, createEncoder, type EncodedBlock, type LtEncoder } from 'luby-transform'
-import { renderSVG } from 'uqr'
-import { useKiloBytesNumberFormat } from '~/composables/intlNumberFormat'
+import { renderSVGDual } from '~/utils/qr'
 
 const props = withDefaults(defineProps<{
   data: Uint8Array
@@ -21,22 +20,60 @@ watch(() => [props.data, props.sliceSize], () => {
   encoder = createEncoder(props.data, props.sliceSize)
 }, { immediate: true })
 const svg = ref<string>()
-const block = shallowRef<EncodedBlock>()
+const blocks = shallowRef<[EncodedBlock, EncodedBlock]>()
 
 const renderTime = ref(0)
 const framePerSecond = computed(() => 1000 / renderTime.value)
-const bytes = useKiloBytesNumberFormat(computed(() => ((block.value?.bytes || 0) / 1024).toFixed(2)))
+
+const formattedIndices = computed(() => {
+  const _blocks = blocks.value
+  if (!_blocks) {
+    return '-, -'
+  }
+  return `${_blocks[0].indices}, ${_blocks[1].indices}`
+})
+
+const formattedK = computed(() => {
+  const _blocks = blocks.value
+  if (!_blocks) {
+    return '-, -'
+  }
+  return `${_blocks[0].k}, ${_blocks[1].k}`
+})
+
+const formattedKBytes = computed(() => {
+  const rawKB = useNumberFormat(computed(() => {
+    const _blocks = blocks.value
+    if (!_blocks) {
+      return '0.00'
+    }
+    return ((_blocks[0].bytes + _blocks[1].bytes) / 1024).toFixed(2)
+  }))
+  return `${rawKB.value} KB`
+})
+
+const formattedKbps = computed(() => {
+  const rawKbps = useNumberFormat(computed(() => {
+    const _blocks = blocks.value
+    if (!_blocks) {
+      return '0.00'
+    }
+    return ((_blocks[0].bytes + _blocks[1].bytes) / 1024 * framePerSecond.value * 8).toFixed(2)
+  }))
+  return `${rawKbps.value} Kbps`
+})
 
 onMounted(() => {
   let frame = performance.now()
 
   useIntervalFn(() => {
-    count.value++
-    const data = encoder.fountain().next().value
-    block.value = data
-    const binary = blockToBinary(data)
-    const str = fromUint8Array(binary)
-    svg.value = renderSVG(str, { border: 5 })
+    count.value += 2
+    const block1 = encoder.fountain().next().value
+    const block2 = encoder.fountain().next().value
+    const ch1 = fromUint8Array(blockToBinary(block1))
+    const ch2 = fromUint8Array(blockToBinary(block2))
+    blocks.value = [block1, block2]
+    svg.value = renderSVGDual(ch1, ch2, { border: 5 })
     const now = performance.now()
     renderTime.value = now - frame
     frame = now
@@ -49,13 +86,13 @@ onMounted(() => {
     <Collapsable w-full>
       <div grid-cols="[150px_1fr]" font="mono!" grid w-full gap-x-4 gap-y-2 overflow-x-auto whitespace-nowrap p2 text-sm>
         <span text-neutral-500>Indices</span>
-        <span text-right md:text-left>{{ block?.indices }}</span>
+        <span text-right md:text-left>{{ formattedIndices }}</span>
         <span text-neutral-500>Total</span>
-        <span text-right md:text-left>{{ block?.k }}</span>
+        <span text-right md:text-left>{{ formattedK }}</span>
         <span text-neutral-500>Bytes</span>
-        <span text-right md:text-left>{{ bytes }}</span>
+        <span text-right md:text-left>{{ formattedKBytes }}</span>
         <span text-neutral-500>Bitrate</span>
-        <span text-right md:text-left>{{ ((block?.bytes || 0) / 1024 * framePerSecond).toFixed(2) }} Kbps</span>
+        <span text-right md:text-left>{{ formattedKbps }}</span>
         <span text-neutral-500>Frame Count</span>
         <span text-right md:text-left>{{ count }}</span>
         <span text-neutral-500>FPS</span>
@@ -70,7 +107,6 @@ onMounted(() => {
       <div relative w-full>
         <div
           class="aspect-square [&>svg]:h-full [&>svg]:w-full"
-
           h-full w-full overflow-hidden rounded="~ sm:lg"
           v-html="svg"
         />

--- a/app/components/Scan.vue
+++ b/app/components/Scan.vue
@@ -109,6 +109,31 @@ onMounted(async () => {
           error.value = e
         }
       },
+      async decodeMultiplexer(canvasContext, decode) {
+        const imageData = canvasContext.getImageData(0, 0, canvasContext.canvas.width, canvasContext.canvas.height)
+        const data = imageData.data
+        const length = data.length
+        const blue: number[] = Array.from({ length: length / 4 })
+
+        // RED-only channel
+        for (let i = 0; i < length; i += 4) {
+          data[i + 1] = data[i]!
+          blue[i / 4] = data[i + 2] ?? 0
+          data[i + 2] = data[i]!
+        }
+        canvasContext.putImageData(imageData, 0, 0)
+        await decode()
+
+        // BLUE-only channel
+        for (let i = 0; i < length; i += 4) {
+          const b = blue[i / 4] ?? 0
+          data[i] = b
+          data[i + 1] = b
+          data[i + 2] = b
+        }
+        canvasContext.putImageData(imageData, 0, 0)
+        await decode()
+      },
     })
     selectedCamera.value && qrScanner.setCamera(selectedCamera.value)
     qrScanner.setInversionMode('both')

--- a/app/components/Scan.vue
+++ b/app/components/Scan.vue
@@ -113,26 +113,30 @@ onMounted(async () => {
         const imageData = canvasContext.getImageData(0, 0, canvasContext.canvas.width, canvasContext.canvas.height)
         const data = imageData.data
         const length = data.length
-        const blue: number[] = Array.from({ length: length / 4 })
 
-        // RED-only channel
-        for (let i = 0; i < length; i += 4) {
-          data[i + 1] = data[i]!
-          blue[i / 4] = data[i + 2] ?? 0
-          data[i + 2] = data[i]!
+        // This should scan the BLACK + RED channel
+        try {
+          await decode()
         }
-        canvasContext.putImageData(imageData, 0, 0)
-        await decode()
+        // eslint-disable-next-line unused-imports/no-unused-vars
+        catch (e) {
+          // TODO: Better error handling
+        }
 
+        // Comment out lines below to mimic the default behavior
         // BLUE-only channel
         for (let i = 0; i < length; i += 4) {
-          const b = blue[i / 4] ?? 0
-          data[i] = b
-          data[i + 1] = b
-          data[i + 2] = b
+          data[i] = data[i + 2]!
+          data[i + 1] = data[i + 2]!
         }
         canvasContext.putImageData(imageData, 0, 0)
-        await decode()
+        try {
+          await decode()
+        }
+        // eslint-disable-next-line unused-imports/no-unused-vars
+        catch (e) {
+          // This is good to have, but not necessary
+        }
       },
     })
     selectedCamera.value && qrScanner.setCamera(selectedCamera.value)

--- a/app/utils/qr.ts
+++ b/app/utils/qr.ts
@@ -1,0 +1,56 @@
+import { encode, type QrCodeGenerateData, type QrCodeGenerateSvgOptions } from 'uqr'
+
+/**
+ * This function accepts data from two channels, appends padding to the shorter one (unless they are
+ * of equal length), encodes them into QR codes, and renders them into SVG.
+ *
+ * @param ch1 data from the channel 1
+ * @param ch2 data from the channel 2
+ * @param options QrCodeGenerateSvgOptions
+ * @returns SVG string
+ */
+export function renderSVGDual(ch1: QrCodeGenerateData, ch2: QrCodeGenerateData, options: QrCodeGenerateSvgOptions = {}) {
+  const padding = ' '.repeat(Math.abs(ch1.length - ch2.length))
+
+  const ch1data = encode(ch1.length > ch2.length ? ch1 : `${ch1}${padding}`, options)
+  const ch2data = encode(ch2.length > ch1.length ? ch2 : `${ch2}${padding}`, options)
+
+  const { pixelSize = 10 } = options
+  const size = ch1data.size
+  const height = size * pixelSize
+  const width = size * pixelSize
+
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">`
+
+  let ch1path = ''
+  let ch2path = ''
+  let bothPath = ''
+
+  for (let row = 0; row < size; row++) {
+    for (let col = 0; col < size; col++) {
+      const x = col * pixelSize
+      const y = row * pixelSize
+      const onCh1 = ch1data.data[row]?.[col]
+      const onCh2 = ch2data.data[row]?.[col]
+
+      if (onCh1 && onCh2) {
+        bothPath += `M${x},${y}h${pixelSize}v${pixelSize}h-${pixelSize}z`
+      }
+      else if (onCh1) {
+        ch1path += `M${x},${y}h${pixelSize}v${pixelSize}h-${pixelSize}z`
+      }
+      else if (onCh2) {
+        ch2path += `M${x},${y}h${pixelSize}v${pixelSize}h-${pixelSize}z`
+      }
+    }
+  }
+
+  svg += `<rect fill="white" width="${width}" height="${height}"/>`
+  // This allows the "black" blocks remain "dark" in the RED/BLUE-only channel while decoding
+  svg += `<path fill="rgb(0, 255, 255)" d="${ch1path}"/>`
+  svg += `<path fill="rgb(255, 255, 0)" d="${ch2path}"/>`
+  svg += `<path fill="rgb(0, 0, 0)" d="${bothPath}"/>`
+
+  svg += '</svg>'
+  return svg
+}

--- a/app/utils/qr.ts
+++ b/app/utils/qr.ts
@@ -45,11 +45,11 @@ export function renderSVGDual(ch1: QrCodeGenerateData, ch2: QrCodeGenerateData, 
     }
   }
 
-  svg += `<rect fill="white" width="${width}" height="${height}"/>`
+  svg += `<rect fill="black" width="${width}" height="${height}"/>`
   // This allows the "black" blocks remain "dark" in the RED/BLUE-only channel while decoding
-  svg += `<path fill="rgb(0, 255, 255)" d="${ch1path}"/>`
-  svg += `<path fill="rgb(255, 255, 0)" d="${ch2path}"/>`
-  svg += `<path fill="rgb(0, 0, 0)" d="${bothPath}"/>`
+  svg += `<path fill="rgb(255, 0, 0)" d="${ch1path}"/>`
+  svg += `<path fill="rgb(0, 0, 255)" d="${ch2path}"/>`
+  svg += `<path fill="rgb(255, 0, 255)" d="${bothPath}"/>`
 
   svg += '</svg>'
   return svg

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "js-base64": "^3.7.7",
-    "qr-scanner": "^1.4.2",
+    "qr-scanner": "github:qifi-dev/qr-scanner#7621e78f311c7c3cb254bff1c54d1d8776b5770c",
     "uqr": "^0.1.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.7.7
         version: 3.7.7
       qr-scanner:
-        specifier: ^1.4.2
-        version: 1.4.2
+        specifier: github:qifi-dev/qr-scanner#7621e78f311c7c3cb254bff1c54d1d8776b5770c
+        version: https://codeload.github.com/qifi-dev/qr-scanner/tar.gz/7621e78f311c7c3cb254bff1c54d1d8776b5770c
       uqr:
         specifier: ^0.1.2
         version: 0.1.2
@@ -5181,8 +5181,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qr-scanner@1.4.2:
-    resolution: {integrity: sha512-kV1yQUe2FENvn59tMZW6mOVfpq9mGxGf8l6+EGaXUOd4RBOLg7tRC83OrirM5AtDvZRpdjdlXURsHreAOSPOUw==}
+  qr-scanner@https://codeload.github.com/qifi-dev/qr-scanner/tar.gz/7621e78f311c7c3cb254bff1c54d1d8776b5770c:
+    resolution: {tarball: https://codeload.github.com/qifi-dev/qr-scanner/tar.gz/7621e78f311c7c3cb254bff1c54d1d8776b5770c}
+    version: 1.4.2
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -12470,7 +12471,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qr-scanner@1.4.2:
+  qr-scanner@https://codeload.github.com/qifi-dev/qr-scanner/tar.gz/7621e78f311c7c3cb254bff1c54d1d8776b5770c:
     dependencies:
       '@types/offscreencanvas': 2019.7.3
 


### PR DESCRIPTION
## Summary

This PR adds an experimental feature that combines two QR codes into one by encoding them in different color channels to double the payload of each frame.

`decodeMultiplexer` from https://github.com/qifi-dev/qr-scanner/commit/7621e78f311c7c3cb254bff1c54d1d8776b5770c is necessary to allow the pre-decode processing in this consuming project.

Please feel free to add switches in the UI to make this an optional feature.

This PR also fixes the unit format (1000 based `kB` → 1024 based `KB`) and the bitrate calculation (multiplying by 8) in the Generate page.

## Demo

_(Unaccelerated)_
 
![Demo-Dual-Channel](https://github.com/user-attachments/assets/c66719c2-d232-4570-a975-4ab7b192df77)
