### PR TITLE
fix(decoder): enable and fix resolving test case('cross-blocks resolving 3')

### DIFF
--- a/packages/luby-transform/src/shared.ts
+++ b/packages/luby-transform/src/shared.ts
@@ -66,3 +66,15 @@ export function xorUint8Array(a: Uint8Array, b: Uint8Array): Uint8Array {
 
   return result
 }
+
+// Check if one array is a subset of the other.
+export function isEitherArraySubset(
+  setA: number[],
+  setB: number[],
+): boolean {
+  const [optimizedSet, checkSet] = setA.length > setB.length
+    ? [new Set(setA), setB]
+    : [new Set(setB), setA]
+
+  return checkSet.every(e => optimizedSet.has(e))
+}

--- a/packages/luby-transform/test/lt-blocks.test.ts
+++ b/packages/luby-transform/test/lt-blocks.test.ts
@@ -44,8 +44,7 @@ it('cross-blocks resolving 2', () => {
   expect(data).toEqual(buffer)
 })
 
-// TODO: get it work
-it.skip('cross-blocks resolving 3', () => {
+it('cross-blocks resolving 3', () => {
   const { buffer, encoder } = createEncoderWithIndices(5)
 
   const decoder = createDecoder()
@@ -60,6 +59,9 @@ it.skip('cross-blocks resolving 3', () => {
   // Here we can have [0] and [1]
   expect(decoder.decodedCount).toBe(3)
   decoder.addBlock(encoder.createBlock([4]))
+  decoder.addBlock(encoder.createBlock([2, 4]))
+  // Here we can have [2] and [3]
+  expect(decoder.decodedCount).toBe(5)
 
   const data = decoder.getDecoded()
   expect(data).toBeDefined()


### PR DESCRIPTION
1. Modified the decode method for Luby-Transform codes to make it pass the test case ('cross-blocks resolving 3').
2. The test case ('cross-blocks resolving 3') was previously incomplete, and its code has now been improved.